### PR TITLE
Fix reference to usersrolespermissions.sql

### DIFF
--- a/os.sql
+++ b/os.sql
@@ -2,7 +2,7 @@
 \i scheduler.sql
 \i locks.sql
 \i signals.sql
-\i userrolespermissions.sql
+\i usersrolespermissions.sql
 \i memory.sql
 \i fs.sql
 \i ipc.sql


### PR DESCRIPTION
## Summary
- fix include path in `os.sql`

## Testing
- `git diff --color --unified=5 os.sql`


------
https://chatgpt.com/codex/tasks/task_e_683f41d90ad883289ea412c79be57988