### PR TITLE
Add gitignore and simple regression test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,20 @@
+# PostgreSQL extension build artifacts
+*.so
+*.o
+*.lo
+*.la
+*.sl
+*.dll
+*.log
+*.diffs
+*.out
+!expected/*.out
+
+# Regression test outputs
+/results/
+/tmp_check/
+
+# Backup and temp files
+*~
+*.swp
+*.swo

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
 EXTENSION = pg_os
 DATA = pg_os--1.0.sql
 PG_CONFIG ?= pg_config
+REGRESS = pg_os_basic
 PGXS := $(shell $(PG_CONFIG) --pgxs)
 include $(PGXS)

--- a/expected/pg_os_basic.out
+++ b/expected/pg_os_basic.out
@@ -1,0 +1,7 @@
+-- simple regression test
+SELECT 1 AS one;
+ one 
+-----
+   1
+(1 row)
+

--- a/sql/pg_os_basic.sql
+++ b/sql/pg_os_basic.sql
@@ -1,0 +1,2 @@
+-- simple regression test
+SELECT 1 AS one;


### PR DESCRIPTION
## Summary
- ignore typical build artifacts and regression output
- add a simple regression test using pg_regress
- configure Makefile to run the regression test

## Testing
- `make installcheck`

------
https://chatgpt.com/codex/tasks/task_e_68419763d2888328b52b7b2bf56ee661