### PR TITLE
Fix qualification in SQL functions

### DIFF
--- a/fs.sql
+++ b/fs.sql
@@ -152,7 +152,9 @@ $$ LANGUAGE plpgsql;
 -- Unlock a file
 CREATE OR REPLACE FUNCTION unlock_file(user_id INTEGER, file_id INTEGER) RETURNS VOID AS $$
 BEGIN
-    DELETE FROM file_locks WHERE file_id=file_id AND locked_by_user=user_id;
+    DELETE FROM file_locks
+        WHERE file_id = unlock_file.file_id
+          AND locked_by_user = user_id;
 END;
 $$ LANGUAGE plpgsql;
 
@@ -168,7 +170,10 @@ BEGIN
         RAISE EXCEPTION 'File not found';
     END IF;
 
-    SELECT COALESCE(MAX(version_number),0) INTO max_version FROM file_versions WHERE file_id=file_id;
-    INSERT INTO file_versions (file_id, version_number, contents) VALUES (file_id, max_version+1, f.contents);
+    SELECT COALESCE(MAX(version_number),0) INTO max_version
+        FROM file_versions
+        WHERE file_versions.file_id = version_file.file_id;
+    INSERT INTO file_versions (file_id, version_number, contents)
+        VALUES (file_id, max_version+1, f.contents);
 END;
 $$ LANGUAGE plpgsql;

--- a/gc.sql
+++ b/gc.sql
@@ -31,9 +31,14 @@ CREATE OR REPLACE FUNCTION free_all_memory_for_process(process_id INTEGER) RETUR
 DECLARE
     seg_id INTEGER;
 BEGIN
-    FOR seg_id IN SELECT segment_id FROM process_memory WHERE process_id = process_id LOOP
+    FOR seg_id IN
+        SELECT segment_id
+          FROM process_memory
+         WHERE process_memory.process_id = free_all_memory_for_process.process_id LOOP
         UPDATE memory_segments SET allocated = FALSE, allocated_to = NULL WHERE id = seg_id;
-        DELETE FROM process_memory WHERE process_id = process_id AND segment_id = seg_id;
+        DELETE FROM process_memory
+         WHERE process_memory.process_id = free_all_memory_for_process.process_id
+           AND segment_id = seg_id;
     END LOOP;
 END;
 $$ LANGUAGE plpgsql;


### PR DESCRIPTION
## Summary
- qualify file variables in fs.sql for proper references
- fix process memory variable references in gc.sql

## Testing
- `make` *(fails: pgxs.mk not found)*

------
https://chatgpt.com/codex/tasks/task_e_68419763248c83289d2bbc41676ae4ee