### PR TITLE
Fix script order in os.sql

### DIFF
--- a/os.sql
+++ b/os.sql
@@ -1,8 +1,8 @@
+\i usersrolespermissions.sql
 \i processes.sql
 \i scheduler.sql
 \i locks.sql
 \i signals.sql
-\i usersrolespermissions.sql
 \i memory.sql
 \i fs.sql
 \i ipc.sql


### PR DESCRIPTION
## Summary
- ensure user/role permissions script loads before process definitions

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_68419761e93883288babe9e09ccf9b3f