### PR TITLE
Add cascading file ownership constraints

### DIFF
--- a/fs.sql
+++ b/fs.sql
@@ -6,8 +6,8 @@
 CREATE TABLE IF NOT EXISTS files (
     id SERIAL PRIMARY KEY,
     name TEXT NOT NULL,
-    parent_id INTEGER REFERENCES files(id),  -- Directory structure
-    owner_user_id INTEGER REFERENCES users(id),
+    parent_id INTEGER REFERENCES files(id) ON DELETE CASCADE,  -- Directory structure; cascade deletes
+    owner_user_id INTEGER NOT NULL REFERENCES users(id) ON DELETE CASCADE,  -- Owner; cascades on user delete
     permissions TEXT NOT NULL,  -- e.g. 'rwxr-x---'
     contents TEXT DEFAULT '',
     is_directory BOOLEAN DEFAULT FALSE,

--- a/pg_os--1.0.sql
+++ b/pg_os--1.0.sql
@@ -788,8 +788,8 @@ $$ LANGUAGE plpgsql;
 CREATE TABLE IF NOT EXISTS files (
     id SERIAL PRIMARY KEY,
     name TEXT NOT NULL,
-    parent_id INTEGER REFERENCES files(id),  -- Directory structure
-    owner_user_id INTEGER REFERENCES users(id),
+    parent_id INTEGER REFERENCES files(id) ON DELETE CASCADE,  -- Directory structure; cascade deletes
+    owner_user_id INTEGER NOT NULL REFERENCES users(id) ON DELETE CASCADE,  -- Owner; cascades on user delete
     permissions TEXT NOT NULL,  -- e.g. 'rwxr-x---'
     contents TEXT DEFAULT '',
     is_directory BOOLEAN DEFAULT FALSE,

--- a/sql/fs_constraints_migration.sql
+++ b/sql/fs_constraints_migration.sql
@@ -1,0 +1,26 @@
+-- Migration script to enforce ownership and cascading deletes on files table
+
+-- Assign default owner (id 1) where owner is missing or invalid
+UPDATE files f
+SET owner_user_id = 1
+WHERE owner_user_id IS NULL
+   OR NOT EXISTS (
+       SELECT 1 FROM users u WHERE u.id = f.owner_user_id
+   );
+
+-- Remove files whose parent reference is invalid
+DELETE FROM files f
+WHERE parent_id IS NOT NULL
+  AND NOT EXISTS (
+      SELECT 1 FROM files p WHERE p.id = f.parent_id
+  );
+
+-- Drop existing foreign key constraints
+ALTER TABLE files DROP CONSTRAINT IF EXISTS files_parent_id_fkey;
+ALTER TABLE files DROP CONSTRAINT IF EXISTS files_owner_user_id_fkey;
+
+-- Apply NOT NULL and cascading foreign key constraints
+ALTER TABLE files
+    ALTER COLUMN owner_user_id SET NOT NULL,
+    ADD CONSTRAINT files_parent_id_fkey FOREIGN KEY (parent_id) REFERENCES files(id) ON DELETE CASCADE,
+    ADD CONSTRAINT files_owner_user_id_fkey FOREIGN KEY (owner_user_id) REFERENCES users(id) ON DELETE CASCADE;


### PR DESCRIPTION
## Summary
- enforce cascading deletes for files table and require owner_user_id
- add migration script to clean up orphaned files and apply new constraints

## Testing
- `make installcheck`


------
https://chatgpt.com/codex/tasks/task_e_688fb5768e108328a5844117eda65b45