### PR TITLE
Add cascading deletes to process logs and threads

### DIFF
--- a/pg_os--1.0.sql
+++ b/pg_os--1.0.sql
@@ -144,7 +144,7 @@ CREATE TABLE processes (
 -- process logs
 CREATE TABLE IF NOT EXISTS process_logs (
     id SERIAL PRIMARY KEY,
-    process_id INTEGER REFERENCES processes(id),
+    process_id INTEGER REFERENCES processes(id) ON DELETE CASCADE,
     action TEXT NOT NULL,
     timestamp TIMESTAMP DEFAULT now()
 );
@@ -368,7 +368,7 @@ CREATE TABLE IF NOT EXISTS scheduler_config (
 -- threads
 CREATE TABLE IF NOT EXISTS threads (
     id SERIAL PRIMARY KEY,
-    process_id INTEGER NOT NULL REFERENCES processes(id),
+    process_id INTEGER NOT NULL REFERENCES processes(id) ON DELETE CASCADE,
     name TEXT NOT NULL,
     state TEXT CHECK (state IN ('new', 'ready', 'running', 'waiting', 'terminated')) DEFAULT 'new',
     priority INTEGER DEFAULT 1,

--- a/processes.sql
+++ b/processes.sql
@@ -17,7 +17,7 @@ CREATE TABLE processes (
 -- process logs
 CREATE TABLE IF NOT EXISTS process_logs (
     id SERIAL PRIMARY KEY,
-    process_id INTEGER REFERENCES processes(id),
+    process_id INTEGER REFERENCES processes(id) ON DELETE CASCADE,
     action TEXT NOT NULL,
     timestamp TIMESTAMP DEFAULT now()
 );

--- a/scheduler.sql
+++ b/scheduler.sql
@@ -14,7 +14,7 @@ CREATE TABLE IF NOT EXISTS scheduler_config (
 -- threads
 CREATE TABLE IF NOT EXISTS threads (
     id SERIAL PRIMARY KEY,
-    process_id INTEGER NOT NULL REFERENCES processes(id),
+    process_id INTEGER NOT NULL REFERENCES processes(id) ON DELETE CASCADE,
     name TEXT NOT NULL,
     state TEXT CHECK (state IN ('new', 'ready', 'running', 'waiting', 'terminated')) DEFAULT 'new',
     priority INTEGER DEFAULT 1,


### PR DESCRIPTION
## Summary
- ensure process_logs rows are removed when their parent process is deleted
- ensure threads are removed when their parent process is deleted

## Testing
- `make`
- `sudo -u postgres make installcheck` *(fails: lock_file)*

------
https://chatgpt.com/codex/tasks/task_e_6890d50523148328a0b2af10b1a45bbf