### PR TITLE
Ensure advisory locks are always released

### DIFF
--- a/memory.sql
+++ b/memory.sql
@@ -55,11 +55,16 @@ BEGIN
         END IF;
 
         -- Transaction block for atomic allocation
-        PERFORM pg_advisory_lock(1);  -- simulate locking, ensure no other transaction interferes
-        UPDATE memory_segments SET allocated = TRUE, allocated_to = process_id WHERE id = mem_seg.id;
-        INSERT INTO process_memory (process_id, segment_id)
-            VALUES (allocate_memory.process_id, mem_seg.id);
-        PERFORM pg_advisory_unlock(1);
+        BEGIN
+            PERFORM pg_advisory_lock(1);  -- simulate locking, ensure no other transaction interferes
+            UPDATE memory_segments SET allocated = TRUE, allocated_to = process_id WHERE id = mem_seg.id;
+            INSERT INTO process_memory (process_id, segment_id)
+                VALUES (allocate_memory.process_id, mem_seg.id);
+            PERFORM pg_advisory_unlock(1);
+        EXCEPTION WHEN others THEN
+            PERFORM pg_advisory_unlock(1);
+            RAISE;
+        END;
 
         -- Log the allocation
         PERFORM log_memory_action(process_id, 'Memory allocated: segment ' || mem_seg.id, user_id, mem_seg.id);


### PR DESCRIPTION
## Summary
- guard advisory lock calls with a nested BEGIN/EXCEPTION block
- rethrow exceptions after unlocking to avoid leaving locks held

## Testing
- `make test` *(fails: No rule to make target '/usr/lib/postgresql/16/lib/pgxs/src/makefiles/pgxs.mk')*

------
https://chatgpt.com/codex/tasks/task_e_6890d5035608832886e74bb472853e90