### PR TITLE
Consolidate scheduler routine and fix process execution

### DIFF
--- a/scheduler.sql
+++ b/scheduler.sql
@@ -77,7 +77,7 @@ BEGIN
         END IF;
 
         -- Execute the chosen process
-        PERFORM execute_process(next_process.id);
+        CALL execute_process(next_process.id);
 
     END LOOP;
 END;


### PR DESCRIPTION
## Summary
- Remove procedure variant of `schedule_processes` and keep function version
- Call `execute_process` with `CALL` and drop nested transactions
- Simplify `execute_process` to rely on caller-managed transactions

## Testing
- `make install`
- `make installcheck` *(fails: lock_file)*

------
https://chatgpt.com/codex/tasks/task_e_6890d5015784832881428b07ed514253