### PR TITLE
Add unique constraint to processes name

### DIFF
--- a/pg_os--1.0.sql
+++ b/pg_os--1.0.sql
@@ -132,7 +132,7 @@ $$ LANGUAGE plpgsql;
 -- processes
 CREATE TABLE processes (
     id SERIAL PRIMARY KEY,
-    name TEXT NOT NULL,
+    name TEXT NOT NULL UNIQUE,
     state TEXT NOT NULL CHECK (state IN ('new', 'ready', 'running', 'waiting', 'terminated')),
     priority INTEGER DEFAULT 1, -- Higher numbers = higher priority
     created_at TIMESTAMP DEFAULT now(),

--- a/processes.sql
+++ b/processes.sql
@@ -5,7 +5,7 @@
 -- processes
 CREATE TABLE processes (
     id SERIAL PRIMARY KEY,
-    name TEXT NOT NULL,
+    name TEXT NOT NULL UNIQUE,
     state TEXT NOT NULL CHECK (state IN ('new', 'ready', 'running', 'waiting', 'terminated')),
     priority INTEGER DEFAULT 1, -- Higher numbers = higher priority
     created_at TIMESTAMP DEFAULT now(),


### PR DESCRIPTION
## Summary
- add unique constraint on processes.name to prevent duplicates
- mirror unique constraint in extension script

## Testing
- `sudo -u postgres psql -d postgres -c "DROP EXTENSION IF EXISTS pg_os CASCADE; CREATE EXTENSION pg_os;"` *(fails: syntax error at or near "SELECT")*
- `sudo -u postgres psql -d postgres -f processes.sql` *(fails: syntax error at or near "TRANSACTION")*
- `make installcheck PGUSER=postgres` *(fails: Peer authentication failed for user "postgres")*


------
https://chatgpt.com/codex/tasks/task_e_6890d500f930832897a520f9e6510f53