### PR TITLE
Log memory frees

### DIFF
--- a/memory.sql
+++ b/memory.sql
@@ -90,7 +90,7 @@ BEGIN
     UPDATE memory_segments
         SET allocated = FALSE, allocated_to = NULL
         WHERE id = free_memory.segment_id;
-    PERFORM log_process_action(process_id, 'Memory freed: segment ' || segment_id);
+    PERFORM log_memory_action(process_id, 'Memory freed: segment ' || segment_id, user_id, segment_id);
 END;
 $$ LANGUAGE plpgsql;
 

--- a/pg_os--1.0.sql
+++ b/pg_os--1.0.sql
@@ -694,7 +694,7 @@ BEGIN
 
     DELETE FROM process_memory WHERE process_id = process_id AND segment_id = segment_id;
     UPDATE memory_segments SET allocated = FALSE, allocated_to = NULL WHERE id = segment_id;
-    PERFORM log_process_action(process_id, 'Memory freed: segment ' || segment_id);
+    PERFORM log_memory_action(process_id, 'Memory freed: segment ' || segment_id, user_id, segment_id);
 END;
 $$ LANGUAGE plpgsql;
 


### PR DESCRIPTION
## Summary
- ensure `free_memory` records memory deallocations by logging to `memory_logs`
- update extension script to mirror new memory logging

## Testing
- `make`
- `make installcheck` *(fails: connection to server on socket "/var/run/postgresql/.s.PGSQL.5432" failed: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_689396cfc3fc83289be918f5c7708516