### PR TITLE
Prevent table recreation errors in processes.sql

### DIFF
--- a/processes.sql
+++ b/processes.sql
@@ -3,7 +3,7 @@
 -------------
 
 -- processes
-CREATE TABLE processes (
+CREATE TABLE IF NOT EXISTS processes (
     id SERIAL PRIMARY KEY,
     name TEXT NOT NULL UNIQUE,
     state TEXT NOT NULL CHECK (state IN ('new', 'ready', 'running', 'waiting', 'terminated')),


### PR DESCRIPTION
## Summary
- use `CREATE TABLE IF NOT EXISTS` for `processes`

## Testing
- `make check` *(fails: No rule to make target '/usr/lib/postgresql/16/lib/pgxs/src/makefiles/pgxs.mk')*

------
https://chatgpt.com/codex/tasks/task_e_689d278bc5b08328850b17ed486259c8