### PR TITLE
Consume messages after channel reads

### DIFF
--- a/ipc.sql
+++ b/ipc.sql
@@ -75,6 +75,7 @@ BEGIN
     END IF;
 
     RETURN QUERY SELECT message FROM channel_messages WHERE channel_id = ch.id ORDER BY timestamp;
+    DELETE FROM channel_messages WHERE channel_id = ch.id;
 END;
 $$ LANGUAGE plpgsql;
 

--- a/pg_os--1.0.sql
+++ b/pg_os--1.0.sql
@@ -1004,6 +1004,7 @@ BEGIN
     END IF;
 
     RETURN QUERY SELECT message FROM channel_messages WHERE channel_id = ch.id ORDER BY timestamp;
+    DELETE FROM channel_messages WHERE channel_id = ch.id;
 END;
 $$ LANGUAGE plpgsql;
 


### PR DESCRIPTION
## Summary
- Remove channel messages immediately after they are read

## Testing
- `PGUSER=postgres make installcheck` *(fails: 1 of 4 tests, lock_file)*

------
https://chatgpt.com/codex/tasks/task_e_689d2789aea48328b58fb42571ad31ed