### PR TITLE
Version files before writes

### DIFF
--- a/fs.sql
+++ b/fs.sql
@@ -75,6 +75,7 @@ BEGIN
         RAISE EXCEPTION 'User % does not have permission to write files', user_id;
     END IF;
 
+    PERFORM version_file(file_id);
     UPDATE files SET contents = data WHERE id = file_id;
 END;
 $$ LANGUAGE plpgsql;


### PR DESCRIPTION
## Summary
- version files before overwriting contents

## Testing
- `make installcheck` *(fails: 1 of 4 tests failed: lock_file)*

------
https://chatgpt.com/codex/tasks/task_e_689d278af49883288501cee6e8e9d97d