### PR TITLE
Use process-specific duration in execute_process

### DIFF
--- a/processes.sql
+++ b/processes.sql
@@ -77,6 +77,8 @@ $$;
 CREATE OR REPLACE PROCEDURE execute_process(process_id INTEGER)
 LANGUAGE plpgsql
 AS $$
+DECLARE
+    exec_duration INTEGER;
 BEGIN
     -- Check if the process is ready
     UPDATE processes
@@ -92,7 +94,11 @@ BEGIN
     PERFORM log_process_action(process_id, 'Execution started');
 
     -- Simulate work
-    PERFORM pg_sleep(1);
+    SELECT duration INTO exec_duration FROM processes WHERE id = process_id;
+    IF exec_duration IS NULL OR exec_duration < 0 THEN
+        exec_duration := 0;
+    END IF;
+    PERFORM pg_sleep(exec_duration);
 
     -- Mark process as terminated
     UPDATE processes


### PR DESCRIPTION
## Summary
- execute_process now sleeps for its configured duration and defaults to 0 for invalid values

## Testing
- `make installcheck` (fails: 1 of 4 tests failed - lock_file)


------
https://chatgpt.com/codex/tasks/task_e_689d2787d078832883c73ce0368f530a