### PR TITLE
Lock free_memory updates

### DIFF
--- a/memory.sql
+++ b/memory.sql
@@ -93,13 +93,21 @@ BEGIN
     IF NOT check_permission(user_id, 'memory', 'allocate') THEN
         RAISE EXCEPTION 'User % does not have permission to free memory', user_id;
     END IF;
+    BEGIN
+        PERFORM pg_advisory_lock(1);
 
-    DELETE FROM process_memory
-        WHERE process_id = free_memory.process_id
-          AND segment_id = free_memory.segment_id;
-    UPDATE memory_segments
-        SET allocated = FALSE, allocated_to = NULL
-        WHERE id = free_memory.segment_id;
+        DELETE FROM process_memory
+            WHERE process_id = free_memory.process_id
+              AND segment_id = free_memory.segment_id;
+        UPDATE memory_segments
+            SET allocated = FALSE, allocated_to = NULL
+            WHERE id = free_memory.segment_id;
+
+        PERFORM pg_advisory_unlock(1);
+    EXCEPTION WHEN others THEN
+        PERFORM pg_advisory_unlock(1);
+        RAISE;
+    END;
     PERFORM log_memory_action(process_id, 'Memory freed: segment ' || segment_id, user_id, segment_id);
 END;
 $$ LANGUAGE plpgsql SECURITY DEFINER SET search_path = pg_catalog, pg_temp;


### PR DESCRIPTION
## Summary
- acquire advisory lock when freeing memory segments
- release lock in normal and exception paths

## Testing
- `make installcheck` *(fails: role "pg_os_admin" is reserved and missing)*

------
https://chatgpt.com/codex/tasks/task_e_689e067912a88328b770ecde2286bf14