### PR TITLE
Use atomic delete-returning for channel reads

### DIFF
--- a/ipc.sql
+++ b/ipc.sql
@@ -76,8 +76,10 @@ BEGIN
         RAISE EXCEPTION 'User % does not have permission to read channels', user_id;
     END IF;
 
-    RETURN QUERY SELECT message FROM channel_messages WHERE channel_id = ch.id ORDER BY timestamp;
-    DELETE FROM channel_messages WHERE channel_id = ch.id;
+    RETURN QUERY DELETE FROM channel_messages
+        WHERE channel_id = ch.id
+        ORDER BY timestamp
+        RETURNING message;
 END;
 $$ LANGUAGE plpgsql SECURITY DEFINER SET search_path = pg_catalog, pg_temp;
 ALTER FUNCTION read_channel(INTEGER, TEXT) OWNER TO pg_os_admin;


### PR DESCRIPTION
## Summary
- Fetch and remove channel messages atomically using `DELETE ... RETURNING`
- Return deleted messages directly from `read_channel`

## Testing
- `make installcheck` *(fails: No rule to make target `/usr/lib/postgresql/16/lib/pgxs/src/makefiles/pgxs.mk`)*

------
https://chatgpt.com/codex/tasks/task_e_689e0679c9f88328ad3f01ebf2a06549