### PR TITLE
Version file records before updates

### DIFF
--- a/audit.sql
+++ b/audit.sql
@@ -83,6 +83,7 @@ BEGIN
     END IF;
 
     BEGIN
+        PERFORM version_file(file_id);
         UPDATE files SET contents = data WHERE id = file_id;
         PERFORM log_file_action(file_id, 'write', user_id);
     EXCEPTION WHEN others THEN


### PR DESCRIPTION
## Summary
- call `version_file` before updating file contents

## Testing
- `su postgres -c "cd /workspace/pg_os && make installcheck"` *(fails: 3 of 4 tests failed)*

------
https://chatgpt.com/codex/tasks/task_e_689e067b5b808328af919a8c248cb8bf