### PR TITLE
Separate function terminators from section dividers

### DIFF
--- a/pg_os--1.0.sql
+++ b/pg_os--1.0.sql
@@ -1230,7 +1230,8 @@ BEGIN
         UPDATE device_queue SET completed=TRUE WHERE id=req.id;
     END LOOP;
 END;
-$$ LANGUAGE plpgsql;-------------------------
+$$ LANGUAGE plpgsql;
+-------------------------
 -- NETWORKING
 -------------------------
 
@@ -1265,7 +1266,8 @@ BEGIN
     -- Just simulate logging the send
     RAISE NOTICE 'Sending packet from socket % to %: %', socket_id, s.connected_to, data;
 END;
-$$ LANGUAGE plpgsql;-----------
+$$ LANGUAGE plpgsql;
+-----------
 -- MODULES
 -----------
 
@@ -1288,7 +1290,8 @@ CREATE OR REPLACE FUNCTION unload_module(module_name TEXT) RETURNS VOID AS $$
 BEGIN
     UPDATE modules SET loaded=FALSE WHERE module_name=module_name;
 END;
-$$ LANGUAGE plpgsql;--------------------
+$$ LANGUAGE plpgsql;
+--------------------
 -- POWER MANAGEMENT
 --------------------
 


### PR DESCRIPTION
## Summary
- Insert newline after each PL/pgSQL terminator so hyphen dividers stand on their own lines in networking, modules, and power management sections

## Testing
- `su - postgres -c "psql -f /workspace/pg_os/pg_os--1.0.sql"` *(fails: syntax error at or near "SELECT")*

------
https://chatgpt.com/codex/tasks/task_e_689e12536ea8832899438a9a79a73af3