### PR TITLE
Qualify module column in unload_module

### DIFF
--- a/pg_os--1.0.sql
+++ b/pg_os--1.0.sql
@@ -1286,7 +1286,7 @@ $$ LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION unload_module(module_name TEXT) RETURNS VOID AS $$
 BEGIN
-    UPDATE modules SET loaded=FALSE WHERE module_name=module_name;
+    UPDATE modules SET loaded=FALSE WHERE modules.module_name = unload_module.module_name;
 END;
 $$ LANGUAGE plpgsql;--------------------
 -- POWER MANAGEMENT


### PR DESCRIPTION
## Summary
- fix unload_module to target only specified module

## Testing
- `su postgres -c "cd /workspace/pg_os && make installcheck"`
- `su postgres -c "psql -d postgres -f /tmp/module_test.sql"`

------
https://chatgpt.com/codex/tasks/task_e_689e125275a0832890cef240aaea95b3