### PR TITLE
Qualify module column names in load/unload functions

### DIFF
--- a/modules.sql
+++ b/modules.sql
@@ -12,7 +12,9 @@ CREATE TABLE IF NOT EXISTS modules (
 
 CREATE OR REPLACE FUNCTION load_module(module_name TEXT) RETURNS VOID AS $$
 BEGIN
-    UPDATE modules SET loaded=TRUE WHERE module_name=module_name;
+    UPDATE modules
+    SET loaded = TRUE
+    WHERE modules.module_name = load_module.module_name;
     -- In practice, you'd dynamically execute code or extend functionality
 END;
 $$ LANGUAGE plpgsql SECURITY DEFINER SET search_path = pg_catalog, pg_temp;
@@ -20,7 +22,9 @@ ALTER FUNCTION load_module(TEXT) OWNER TO pg_os_admin;
 
 CREATE OR REPLACE FUNCTION unload_module(module_name TEXT) RETURNS VOID AS $$
 BEGIN
-    UPDATE modules SET loaded=FALSE WHERE module_name=module_name;
+    UPDATE modules
+    SET loaded = FALSE
+    WHERE modules.module_name = unload_module.module_name;
 END;
 $$ LANGUAGE plpgsql SECURITY DEFINER SET search_path = pg_catalog, pg_temp;
 ALTER FUNCTION unload_module(TEXT) OWNER TO pg_os_admin;

--- a/pg_os--1.0.sql
+++ b/pg_os--1.0.sql
@@ -1281,7 +1281,9 @@ CREATE TABLE IF NOT EXISTS modules (
 
 CREATE OR REPLACE FUNCTION load_module(module_name TEXT) RETURNS VOID AS $$
 BEGIN
-    UPDATE modules SET loaded=TRUE WHERE module_name=module_name;
+    UPDATE modules
+    SET loaded = TRUE
+    WHERE modules.module_name = load_module.module_name;
     -- In practice, you'd dynamically execute code or extend functionality
 END;
 $$ LANGUAGE plpgsql;


### PR DESCRIPTION
## Summary
- Ensure `load_module` and `unload_module` update only the targeted module by qualifying column references.
- Align extension script with module management logic.

## Testing
- `make`
- `make installcheck` *(fails: connection to server on socket "/var/run/postgresql/.s.PGSQL.5432" failed: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_689e1d7ff7448328a9adc1e98d78a31e