### PR TITLE
Start PostgreSQL server in CI tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,6 +11,9 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y postgresql postgresql-contrib postgresql-server-dev-all
+      - name: Start PostgreSQL
+        run: |
+          sudo pg_ctlcluster $(pg_config --version | awk '{print $2}' | cut -d. -f1) main start
       - name: Run tests
         run: |
           make install


### PR DESCRIPTION
## Summary
- Ensure CI workflow starts a PostgreSQL cluster before running extension tests

## Testing
- `make install`
- `sudo -u postgres make installcheck`


------
https://chatgpt.com/codex/tasks/task_e_689e1f738f5c8328904c12091b2fbcde