### PR TITLE
Add regression tests for module management

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 EXTENSION = pg_os
 DATA = pg_os--1.0.sql
 PG_CONFIG ?= pg_config
-REGRESS = pg_os_basic create_user lock_file create_process
+REGRESS = pg_os_basic create_user lock_file create_process modules
 PGXS := $(shell $(PG_CONFIG) --pgxs)
 include $(PGXS)

--- a/expected/modules.out
+++ b/expected/modules.out
@@ -1,0 +1,61 @@
+-- tests for load_module and unload_module
+\set ECHO none
+SELECT module_name, loaded FROM modules ORDER BY id;
+ module_name | loaded 
+-------------+--------
+ mod1        | f
+ mod2        | f
+(2 rows)
+
+SELECT load_module('mod1');
+ load_module 
+-------------
+ 
+(1 row)
+
+SELECT module_name, loaded FROM modules ORDER BY id;
+ module_name | loaded 
+-------------+--------
+ mod1        | t
+ mod2        | f
+(2 rows)
+
+SELECT unload_module('mod1');
+ unload_module 
+---------------
+ 
+(1 row)
+
+SELECT module_name, loaded FROM modules ORDER BY id;
+ module_name | loaded 
+-------------+--------
+ mod1        | f
+ mod2        | f
+(2 rows)
+
+SELECT load_module('mod3');
+ load_module 
+-------------
+ 
+(1 row)
+
+SELECT module_name, loaded FROM modules ORDER BY id;
+ module_name | loaded 
+-------------+--------
+ mod1        | f
+ mod2        | f
+(2 rows)
+
+SELECT load_module('mod2');
+ load_module 
+-------------
+ 
+(1 row)
+
+SELECT module_name, loaded FROM modules ORDER BY id;
+ module_name | loaded 
+-------------+--------
+ mod1        | f
+ mod2        | t
+(2 rows)
+

--- a/sql/modules.sql
+++ b/sql/modules.sql
@@ -1,0 +1,53 @@
+-- tests for load_module and unload_module
+\set ECHO none
+SET client_min_messages TO warning;
+
+DROP TABLE IF EXISTS modules CASCADE;
+
+CREATE TABLE modules (
+    id SERIAL PRIMARY KEY,
+    module_name TEXT UNIQUE NOT NULL,
+    loaded BOOLEAN DEFAULT FALSE,
+    code TEXT,
+    created_at TIMESTAMP DEFAULT now()
+);
+
+CREATE OR REPLACE FUNCTION load_module(module_name TEXT) RETURNS VOID AS $$
+BEGIN
+    UPDATE modules
+    SET loaded = TRUE
+    WHERE modules.module_name = load_module.module_name;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE OR REPLACE FUNCTION unload_module(module_name TEXT) RETURNS VOID AS $$
+BEGIN
+    UPDATE modules
+    SET loaded = FALSE
+    WHERE modules.module_name = unload_module.module_name;
+END;
+$$ LANGUAGE plpgsql;
+
+INSERT INTO modules (module_name) VALUES ('mod1'), ('mod2');
+
+\set ECHO queries
+\set VERBOSITY terse
+
+-- initial state
+SELECT module_name, loaded FROM modules ORDER BY id;
+
+-- load mod1
+SELECT load_module('mod1');
+SELECT module_name, loaded FROM modules ORDER BY id;
+
+-- unload mod1
+SELECT unload_module('mod1');
+SELECT module_name, loaded FROM modules ORDER BY id;
+
+-- load non-existent module
+SELECT load_module('mod3');
+SELECT module_name, loaded FROM modules ORDER BY id;
+
+-- load mod2
+SELECT load_module('mod2');
+SELECT module_name, loaded FROM modules ORDER BY id;


### PR DESCRIPTION
## Summary
- add regression test for load_module/unload_module functions
- cover module lifecycle scenarios

## Testing
- `make installcheck`

------
https://chatgpt.com/codex/tasks/task_e_689e4eb6f4908328b17050eec078671e