### PR TITLE
chore: write regression output to tmp directory

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,5 +2,10 @@ EXTENSION = pg_os
 DATA = pg_os--1.0.sql
 PG_CONFIG ?= pg_config
 REGRESS = pg_os_basic create_user lock_file create_process
+
+# Write regression test output to a temporary directory under /tmp so that
+# running `make installcheck` as an unprivileged PostgreSQL user does not
+# require write access to the extension source tree.
+REGRESS_OPTS = --outputdir=/tmp/pg_os_regress
 PGXS := $(shell $(PG_CONFIG) --pgxs)
 include $(PGXS)


### PR DESCRIPTION
## Summary
- direct `installcheck` regression output to a tmp directory so tests don't require write access to the source tree

## Testing
- `su - postgres -c 'cd /workspace/pg_os && make installcheck'`


------
https://chatgpt.com/codex/tasks/task_e_689e4df3f0f08328a3b5ab19c846abb4