### PR TITLE
Filter handled signals by target process

### DIFF
--- a/pg_os--1.0.sql
+++ b/pg_os--1.0.sql
@@ -601,7 +601,7 @@ CREATE OR REPLACE FUNCTION handle_signals(user_id INTEGER, process_id INTEGER) R
 DECLARE
     sig RECORD;
 BEGIN
-    FOR sig IN SELECT * FROM signals WHERE process_id = process_id LOOP
+    FOR sig IN SELECT * FROM signals WHERE process_id = handle_signals.process_id LOOP
         IF sig.signal_type = 'SIGTERM' THEN
             PERFORM terminate_process(user_id, process_id);
         ELSIF sig.signal_type = 'SIGSTOP' THEN

--- a/signals.sql
+++ b/signals.sql
@@ -26,7 +26,7 @@ CREATE OR REPLACE FUNCTION handle_signals(user_id INTEGER, process_id INTEGER) R
 DECLARE
     sig RECORD;
 BEGIN
-    FOR sig IN SELECT * FROM signals WHERE process_id = process_id LOOP
+    FOR sig IN SELECT * FROM signals WHERE process_id = handle_signals.process_id LOOP
         IF sig.signal_type = 'SIGTERM' THEN
             PERFORM terminate_process(user_id, process_id);
         ELSIF sig.signal_type = 'SIGSTOP' THEN


### PR DESCRIPTION
## Summary
- scope `handle_signals` loop to the provided process id
- apply same fix in packaged extension script

## Testing
- `make installcheck`
- Verified `handle_signals` only processes signals for the specified process

------
https://chatgpt.com/codex/tasks/task_e_689e52cabf608328bbadab2911fb998d