### PR TITLE
Set explicit test user for pg_os regression tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,6 @@ EXTENSION = pg_os
 DATA = pg_os--1.0.sql
 PG_CONFIG ?= pg_config
 REGRESS = pg_os_basic create_user lock_file create_process allocate_memory load_unload_module modules check_permission free_all_memory_for_process
-REGRESS_OPTS = --outputdir=/tmp/pg_os_regress
+REGRESS_OPTS = --user=postgres --outputdir=/tmp/pg_os_regress
 PGXS := $(shell $(PG_CONFIG) --pgxs)
 include $(PGXS)


### PR DESCRIPTION
## Summary
- run pg_os regression tests as postgres to avoid missing role build errors

## Testing
- `su - postgres -c 'cd /workspace/pg_os && make installcheck'`


------
https://chatgpt.com/codex/tasks/task_e_689fb1e047408328a60104d1361a6290