### PR TITLE
Use local regression output directory

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,6 @@ EXTENSION = pg_os
 DATA = pg_os--1.0.sql
 PG_CONFIG ?= pg_config
 REGRESS = pg_os_basic create_user lock_file create_process allocate_memory load_unload_module modules check_permission free_all_memory_for_process
-REGRESS_OPTS = --outputdir=/tmp/pg_os_regress
+REGRESS_OPTS = --outputdir=$(CURDIR)/tmp_pg_os_regress
 PGXS := $(shell $(PG_CONFIG) --pgxs)
 include $(PGXS)


### PR DESCRIPTION
## Summary
- write regression test output to a repository-local directory instead of /tmp

## Testing
- `make`
- `make installcheck`


------
https://chatgpt.com/codex/tasks/task_e_689fb28c0c34832895b7dfa30c92c5fb