### PR TITLE
CI: install Postgres dev headers

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ jobs:
         run: |
           sudo apt-get update
           # Install the server, contrib modules and the development headers
-          sudo apt-get install -y postgresql postgresql-contrib libpq-dev
+          sudo apt-get install -y postgresql postgresql-contrib libpq-dev postgresql-server-dev-16
 
       - name: Start PostgreSQL
         run: |


### PR DESCRIPTION
## Summary
- install PostgreSQL server development headers in CI workflow to enable building extension

## Testing
- `make install`
- `sudo -u postgres make installcheck`


------
https://chatgpt.com/codex/tasks/task_e_689fb44d0d448328aca38a8612982f97