### PR TITLE
Declare plpgsql dependency and disable extension relocation

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,8 @@ The extension bridges the gap between the database and the underlying OS, allowi
 
 ## Requirements
 - PostgreSQL 12+
-- PL/pgSQL language extension enabled
+- `plpgsql` extension installed (required)
+- Extension is not relocatable and will install into the database's default schema
 - Sufficient OS-level permissions for system interaction
 
 ## Installation

--- a/pg_os.control
+++ b/pg_os.control
@@ -1,3 +1,4 @@
 comment = 'Operating system utilities via SQL'
 default_version = '1.0'
-relocatable = true
+requires = 'plpgsql'
+relocatable = false


### PR DESCRIPTION
## Summary
- Require `plpgsql` in extension control file and mark extension as non-relocatable
- Document the `plpgsql` dependency and non-relocatable behavior in the README

## Testing
- `make installcheck`

------
https://chatgpt.com/codex/tasks/task_e_689fbc630fe08328adbe024feac545d1