### PR TITLE
Remove pg_os_admin ownership requirement

### DIFF
--- a/audit.sql
+++ b/audit.sql
@@ -45,7 +45,6 @@ BEGIN
     INSERT INTO file_logs (file_id, action, performed_by) VALUES (file_id, action, user_id);
 END;
 $$ LANGUAGE plpgsql SECURITY DEFINER SET search_path = pg_catalog, pg_temp;
-ALTER FUNCTION log_file_action(INTEGER, TEXT, INTEGER) OWNER TO pg_os_admin;
 
 
 -- log for memory
@@ -54,7 +53,6 @@ BEGIN
     INSERT INTO memory_logs (process_id, action, performed_by, segment_id) VALUES (process_id, action, user_id, segment_id);
 END;
 $$ LANGUAGE plpgsql SECURITY DEFINER SET search_path = pg_catalog, pg_temp;
-ALTER FUNCTION log_memory_action(INTEGER, TEXT, INTEGER, INTEGER) OWNER TO pg_os_admin;
 
 
 
@@ -91,7 +89,6 @@ BEGIN
     END;
 END;
 $$ LANGUAGE plpgsql SECURITY DEFINER SET search_path = pg_catalog, pg_temp;
-ALTER FUNCTION write_file(INTEGER, INTEGER, TEXT) OWNER TO pg_os_admin;
 
 
 -- On fault, record the fault and possibly rollback to a checkpoint
@@ -101,4 +98,3 @@ BEGIN
     -- Recovery logic would go here, like restoring from a checkpoint
 END;
 $$ LANGUAGE plpgsql SECURITY DEFINER SET search_path = pg_catalog, pg_temp;
-ALTER FUNCTION handle_fault(INTEGER, TEXT) OWNER TO pg_os_admin;

--- a/gc.sql
+++ b/gc.sql
@@ -24,7 +24,6 @@ BEGIN
     END LOOP;
 END;
 $$ LANGUAGE plpgsql SECURITY DEFINER SET search_path = pg_catalog, pg_temp;
-ALTER FUNCTION cleanup_terminated_processes(INTERVAL) OWNER TO pg_os_admin;
 
 
 -- Helper function to free all memory for a terminated process
@@ -43,4 +42,3 @@ BEGIN
     END LOOP;
 END;
 $$ LANGUAGE plpgsql SECURITY DEFINER SET search_path = pg_catalog, pg_temp;
-ALTER FUNCTION free_all_memory_for_process(INTEGER) OWNER TO pg_os_admin;

--- a/io.sql
+++ b/io.sql
@@ -30,7 +30,6 @@ BEGIN
     INSERT INTO device_queue (device_id, request_type, data) VALUES (dev.id, request_type, data);
 END;
 $$ LANGUAGE plpgsql SECURITY DEFINER SET search_path = pg_catalog, pg_temp;
-ALTER FUNCTION enqueue_io_request(TEXT, TEXT, TEXT) OWNER TO pg_os_admin;
 
 CREATE OR REPLACE FUNCTION process_device_queue(device_name TEXT) RETURNS VOID AS $$
 DECLARE
@@ -49,4 +48,3 @@ BEGIN
     END LOOP;
 END;
 $$ LANGUAGE plpgsql SECURITY DEFINER SET search_path = pg_catalog, pg_temp;
-ALTER FUNCTION process_device_queue(TEXT) OWNER TO pg_os_admin;

--- a/ipc.sql
+++ b/ipc.sql
@@ -38,7 +38,6 @@ BEGIN
     INSERT INTO channels (name) VALUES (channel_name);
 END;
 $$ LANGUAGE plpgsql SECURITY DEFINER SET search_path = pg_catalog, pg_temp;
-ALTER FUNCTION register_channel(INTEGER, TEXT) OWNER TO pg_os_admin;
 
 
 -- Write to a channel
@@ -59,7 +58,6 @@ BEGIN
     VALUES (ch.id, sender_process_id, msg);
 END;
 $$ LANGUAGE plpgsql SECURITY DEFINER SET search_path = pg_catalog, pg_temp;
-ALTER FUNCTION write_channel(INTEGER, TEXT, INTEGER, TEXT) OWNER TO pg_os_admin;
 
 
 -- Read from a channel (retrieve all new messages)
@@ -82,7 +80,6 @@ BEGIN
         RETURNING message;
 END;
 $$ LANGUAGE plpgsql SECURITY DEFINER SET search_path = pg_catalog, pg_temp;
-ALTER FUNCTION read_channel(INTEGER, TEXT) OWNER TO pg_os_admin;
 
 
 -- Send mail
@@ -95,7 +92,6 @@ BEGIN
     INSERT INTO mailbox (recipient_user_id, sender_user_id, message) VALUES (recipient_user_id, sender_user_id, msg);
 END;
 $$ LANGUAGE plpgsql SECURITY DEFINER SET search_path = pg_catalog, pg_temp;
-ALTER FUNCTION send_mail(INTEGER, INTEGER, TEXT) OWNER TO pg_os_admin;
 
 
 -- Check mail
@@ -108,4 +104,3 @@ BEGIN
     RETURN QUERY SELECT message FROM mailbox WHERE recipient_user_id = user_id ORDER BY timestamp;
 END;
 $$ LANGUAGE plpgsql SECURITY DEFINER SET search_path = pg_catalog, pg_temp;
-ALTER FUNCTION check_mail(INTEGER) OWNER TO pg_os_admin;

--- a/locks.sql
+++ b/locks.sql
@@ -26,7 +26,6 @@ BEGIN
     INSERT INTO mutexes (name) VALUES (mutex_name);
 END;
 $$ LANGUAGE plpgsql SECURITY DEFINER SET search_path = pg_catalog, pg_temp;
-ALTER FUNCTION create_mutex(TEXT) OWNER TO pg_os_admin;
 
 
 -- lock mutex
@@ -48,7 +47,6 @@ BEGIN
     END IF;
 END;
 $$ LANGUAGE plpgsql SECURITY DEFINER SET search_path = pg_catalog, pg_temp;
-ALTER FUNCTION lock_mutex(INTEGER, TEXT) OWNER TO pg_os_admin;
 
 
 -- unlock mutex
@@ -72,7 +70,6 @@ BEGIN
     END IF;
 END;
 $$ LANGUAGE plpgsql SECURITY DEFINER SET search_path = pg_catalog, pg_temp;
-ALTER FUNCTION unlock_mutex(INTEGER, TEXT) OWNER TO pg_os_admin;
 
 
 -- create a semaphore
@@ -82,7 +79,6 @@ BEGIN
     VALUES (sem_name, initial_count, max_val);
 END;
 $$ LANGUAGE plpgsql SECURITY DEFINER SET search_path = pg_catalog, pg_temp;
-ALTER FUNCTION create_semaphore(TEXT, INTEGER, INTEGER) OWNER TO pg_os_admin;
 
 
 -- acquire a semaphore. If count is 0, the process must wait
@@ -108,7 +104,6 @@ BEGIN
     END IF;
 END;
 $$ LANGUAGE plpgsql SECURITY DEFINER SET search_path = pg_catalog, pg_temp;
-ALTER FUNCTION acquire_semaphore(INTEGER, TEXT) OWNER TO pg_os_admin;
 
 
 -- release a semaphore. If processes are waiting for this semaphore, one can be moved to ready
@@ -141,6 +136,5 @@ BEGIN
     END IF;
 END;
 $$ LANGUAGE plpgsql SECURITY DEFINER SET search_path = pg_catalog, pg_temp;
-ALTER FUNCTION release_semaphore(INTEGER, TEXT) OWNER TO pg_os_admin;
 
 

--- a/memory.sql
+++ b/memory.sql
@@ -83,7 +83,6 @@ BEGIN
     END;
 END;
 $$ LANGUAGE plpgsql SECURITY DEFINER SET search_path = pg_catalog, pg_temp;
-ALTER FUNCTION allocate_memory(INTEGER, INTEGER, INTEGER) OWNER TO pg_os_admin;
  
 
 
@@ -111,7 +110,6 @@ BEGIN
     PERFORM log_memory_action(process_id, 'Memory freed: segment ' || segment_id, user_id, segment_id);
 END;
 $$ LANGUAGE plpgsql SECURITY DEFINER SET search_path = pg_catalog, pg_temp;
-ALTER FUNCTION free_memory(INTEGER, INTEGER, INTEGER) OWNER TO pg_os_admin;
 
 -- allocate page to process
 CREATE OR REPLACE FUNCTION allocate_page(thread_id INTEGER) RETURNS BIGINT AS $$
@@ -141,4 +139,3 @@ BEGIN
     RETURN virtual_addr;
 END;
 $$ LANGUAGE plpgsql SECURITY DEFINER SET search_path = pg_catalog, pg_temp;
-ALTER FUNCTION allocate_page(INTEGER) OWNER TO pg_os_admin;

--- a/modules.sql
+++ b/modules.sql
@@ -18,7 +18,6 @@ BEGIN
     -- In practice, you'd dynamically execute code or extend functionality
 END;
 $$ LANGUAGE plpgsql SECURITY DEFINER SET search_path = pg_catalog, pg_temp;
-ALTER FUNCTION load_module(TEXT) OWNER TO pg_os_admin;
 
 CREATE OR REPLACE FUNCTION unload_module(module_name TEXT) RETURNS VOID AS $$
 BEGIN
@@ -27,4 +26,3 @@ BEGIN
     WHERE modules.module_name = unload_module.module_name;
 END;
 $$ LANGUAGE plpgsql SECURITY DEFINER SET search_path = pg_catalog, pg_temp;
-ALTER FUNCTION unload_module(TEXT) OWNER TO pg_os_admin;

--- a/network.sql
+++ b/network.sql
@@ -34,4 +34,3 @@ BEGIN
     RAISE NOTICE 'Sending packet from socket % to %: %', socket_id, s.connected_to, data;
 END;
 $$ LANGUAGE plpgsql SECURITY DEFINER SET search_path = pg_catalog, pg_temp;
-ALTER FUNCTION send_packet(INTEGER, TEXT) OWNER TO pg_os_admin;

--- a/power.sql
+++ b/power.sql
@@ -16,4 +16,3 @@ BEGIN
     INSERT INTO power_states (state) VALUES (new_state);
 END;
 $$ LANGUAGE plpgsql SECURITY DEFINER SET search_path = pg_catalog, pg_temp;
-ALTER FUNCTION set_power_state(TEXT) OWNER TO pg_os_admin;

--- a/processes.sql
+++ b/processes.sql
@@ -52,7 +52,6 @@ EXCEPTION
         RAISE EXCEPTION 'Could not create process: %', SQLERRM;
 END;
 $$;
-ALTER PROCEDURE create_process(TEXT, INTEGER, INTEGER) OWNER TO pg_os_admin;
 
 
 CREATE OR REPLACE PROCEDURE start_process(user_id INTEGER, process_id INTEGER)
@@ -80,7 +79,6 @@ EXCEPTION
         RAISE EXCEPTION 'Failed to start process %: %', process_id, SQLERRM;
 END;
 $$;
-ALTER PROCEDURE start_process(INTEGER, INTEGER) OWNER TO pg_os_admin;
 
 
 CREATE OR REPLACE PROCEDURE execute_process(user_id INTEGER, process_id INTEGER)
@@ -128,7 +126,6 @@ EXCEPTION
         RAISE EXCEPTION 'Failed to execute process %: %', process_id, SQLERRM;
 END;
 $$;
-ALTER PROCEDURE execute_process(INTEGER, INTEGER) OWNER TO pg_os_admin;
 
 
 
@@ -141,7 +138,6 @@ BEGIN
     RETURN QUERY SELECT * FROM processes WHERE state = state_filter;
 END;
 $$ LANGUAGE plpgsql SECURITY DEFINER SET search_path = pg_catalog, pg_temp;
-ALTER FUNCTION list_processes_by_state(TEXT) OWNER TO pg_os_admin;
 
 
 -- list all running or ready processes by priority
@@ -151,7 +147,6 @@ BEGIN
     RETURN QUERY SELECT * FROM processes WHERE state IN ('ready', 'running') ORDER BY priority DESC, created_at;
 END;
 $$ LANGUAGE plpgsql SECURITY DEFINER SET search_path = pg_catalog, pg_temp;
-ALTER FUNCTION list_ready_or_running_processes() OWNER TO pg_os_admin;
 
 
 CREATE OR REPLACE FUNCTION set_process_priority(user_id INTEGER, process_id INTEGER, new_priority INTEGER) RETURNS VOID AS $$
@@ -165,7 +160,6 @@ BEGIN
     WHERE id = process_id;
 END;
 $$ LANGUAGE plpgsql SECURITY DEFINER SET search_path = pg_catalog, pg_temp;
-ALTER FUNCTION set_process_priority(INTEGER, INTEGER, INTEGER) OWNER TO pg_os_admin;
 
 
 CREATE OR REPLACE FUNCTION terminate_process(user_id INTEGER, process_id INTEGER) RETURNS VOID AS $$
@@ -180,7 +174,6 @@ BEGIN
     WHERE id = process_id AND state != 'terminated';
 END;
 $$ LANGUAGE plpgsql SECURITY DEFINER SET search_path = pg_catalog, pg_temp;
-ALTER FUNCTION terminate_process(INTEGER, INTEGER) OWNER TO pg_os_admin;
 
 
 -- log process
@@ -189,7 +182,6 @@ BEGIN
     INSERT INTO process_logs (process_id, action) VALUES (process_id, action);
 END;
 $$ LANGUAGE plpgsql SECURITY DEFINER SET search_path = pg_catalog, pg_temp;
-ALTER FUNCTION log_process_action(INTEGER, TEXT) OWNER TO pg_os_admin;
 
 
 -- count states
@@ -199,7 +191,6 @@ BEGIN
     SELECT state, COUNT(*) FROM processes GROUP BY state;
 END;
 $$ LANGUAGE plpgsql SECURITY DEFINER SET search_path = pg_catalog, pg_temp;
-ALTER FUNCTION process_count_by_state() OWNER TO pg_os_admin;
 
 
 CREATE OR REPLACE FUNCTION pause_all_processes(user_id INTEGER) RETURNS VOID AS $$
@@ -213,7 +204,6 @@ BEGIN
     WHERE state IN ('ready', 'running');
 END;
 $$ LANGUAGE plpgsql SECURITY DEFINER SET search_path = pg_catalog, pg_temp;
-ALTER FUNCTION pause_all_processes(INTEGER) OWNER TO pg_os_admin;
 
 
 CREATE OR REPLACE FUNCTION resume_all_waiting_processes(user_id INTEGER) RETURNS VOID AS $$
@@ -227,4 +217,3 @@ BEGIN
     WHERE state = 'waiting';
 END;
 $$ LANGUAGE plpgsql SECURITY DEFINER SET search_path = pg_catalog, pg_temp;
-ALTER FUNCTION resume_all_waiting_processes(INTEGER) OWNER TO pg_os_admin;

--- a/scheduler.sql
+++ b/scheduler.sql
@@ -82,7 +82,6 @@ BEGIN
     END LOOP;
 END;
 $$ LANGUAGE plpgsql SECURITY DEFINER SET search_path = pg_catalog, pg_temp;
-ALTER FUNCTION schedule_processes(INTEGER) OWNER TO pg_os_admin;
 
 
 -- thread scheduler
@@ -106,4 +105,3 @@ BEGIN
     END LOOP;
 END;
 $$ LANGUAGE plpgsql SECURITY DEFINER SET search_path = pg_catalog, pg_temp;
-ALTER FUNCTION schedule_threads() OWNER TO pg_os_admin;

--- a/signals.sql
+++ b/signals.sql
@@ -18,7 +18,6 @@ BEGIN
     PERFORM log_process_action(target_process_id, 'Signal received: ' || signal_type);
 END;
 $$ LANGUAGE plpgsql SECURITY DEFINER SET search_path = pg_catalog, pg_temp;
-ALTER FUNCTION send_signal(INTEGER, TEXT) OWNER TO pg_os_admin;
 
 
 
@@ -42,4 +41,3 @@ BEGIN
     END LOOP;
 END;
 $$ LANGUAGE plpgsql SECURITY DEFINER SET search_path = pg_catalog, pg_temp;
-ALTER FUNCTION handle_signals(INTEGER, INTEGER) OWNER TO pg_os_admin;


### PR DESCRIPTION
## Summary
- drop explicit `OWNER TO pg_os_admin` clauses from module SQL scripts so a special role is no longer required

## Testing
- `sudo -u postgres make installcheck`

------
https://chatgpt.com/codex/tasks/task_e_689fbc6413f8832882f9f17191aff8ac