### PR TITLE
Add regression coverage for file versioning

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 EXTENSION = pg_os
 DATA = pg_os--1.0.sql
 PG_CONFIG ?= pg_config
-REGRESS = pg_os_basic create_user lock_file create_process allocate_memory load_unload_module modules check_permission free_all_memory_for_process
+REGRESS = pg_os_basic create_user lock_file create_process allocate_memory load_unload_module modules check_permission free_all_memory_for_process file_versioning
 REGRESS_OPTS = --outputdir=$(CURDIR)/tmp_pg_os_regress
 PGXS := $(shell $(PG_CONFIG) --pgxs)
 include $(PGXS)

--- a/expected/file_versioning.out
+++ b/expected/file_versioning.out
@@ -1,0 +1,44 @@
+-- tests for file versioning on repeated writes
+\set ECHO none
+SELECT create_user('writer') AS writer_id
+SELECT create_role('file_writer') AS role_id
+SELECT assign_role_to_user(1, 1);
+ assign_role_to_user
+---------------------
+
+(1 row)
+
+SELECT grant_permission_to_role(1, 'file', 'write');
+ grant_permission_to_role
+--------------------------
+
+(1 row)
+
+SELECT create_file(1, 'versioned.txt', NULL, FALSE) AS file_id
+ file_id
+---------
+       1
+(1 row)
+
+SELECT write_file(1, 1, 'first revision');
+ write_file
+------------
+
+(1 row)
+
+SELECT write_file(1, 1, 'second revision');
+ write_file
+------------
+
+(1 row)
+
+SELECT file_id, version_number, contents
+  FROM file_versions
+ WHERE file_id = 1
+ ORDER BY version_number;
+ file_id | version_number |     contents
+---------+----------------+-----------------
+       1 |              1 | 
+       1 |              2 | first revision
+(2 rows)
+

--- a/pg_os--1.0.sql
+++ b/pg_os--1.0.sql
@@ -832,6 +832,7 @@ BEGIN
         RAISE EXCEPTION 'User % does not have permission to write files', user_id;
     END IF;
 
+    PERFORM version_file(file_id);
     UPDATE files SET contents = data WHERE id = file_id;
 END;
 $$ LANGUAGE plpgsql;

--- a/sql/file_versioning.sql
+++ b/sql/file_versioning.sql
@@ -1,0 +1,26 @@
+-- tests for file versioning on repeated writes
+\set ECHO none
+SET client_min_messages TO warning;
+DROP EXTENSION IF EXISTS pg_os CASCADE;
+CREATE EXTENSION pg_os;
+\set ECHO queries
+\set VERBOSITY terse
+
+-- setup: create writer user with file write permission
+SELECT create_user('writer') AS writer_id \gset
+SELECT create_role('file_writer') AS role_id \gset
+SELECT assign_role_to_user(:writer_id, :role_id);
+SELECT grant_permission_to_role(:role_id, 'file', 'write');
+
+-- create a file owned by the writer
+SELECT create_file(:writer_id, 'versioned.txt', NULL, FALSE) AS file_id \gset
+
+-- write twice, generating two versions
+SELECT write_file(:writer_id, :file_id, 'first revision');
+SELECT write_file(:writer_id, :file_id, 'second revision');
+
+-- ensure versions capture each prior state
+SELECT file_id, version_number, contents
+  FROM file_versions
+ WHERE file_id = :file_id
+ ORDER BY version_number;


### PR DESCRIPTION
## Summary
- ensure `write_file` records a version entry before updating file contents
- add a regression test that writes to the same file twice and validates sequential versions
- register the new regression in the build system with expected output

## Testing
- make installcheck *(fails: missing PostgreSQL pgxs.mk in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d6a7bd4fd08328be97d367609ef9a0