### PR TITLE
Validate parent directories when creating files

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 EXTENSION = pg_os
 DATA = pg_os--1.0.sql
 PG_CONFIG ?= pg_config
-REGRESS = pg_os_basic create_user lock_file create_process allocate_memory load_unload_module modules check_permission free_all_memory_for_process
+REGRESS = pg_os_basic create_user create_file lock_file create_process allocate_memory load_unload_module modules check_permission free_all_memory_for_process
 REGRESS_OPTS = --outputdir=$(CURDIR)/tmp_pg_os_regress
 PGXS := $(shell $(PG_CONFIG) --pgxs)
 include $(PGXS)

--- a/expected/create_file.out
+++ b/expected/create_file.out
@@ -1,0 +1,4 @@
+-- tests for create_file parent validation
+\set ECHO none
+SELECT create_file(1, 'child', 1, FALSE);
+ERROR:  Parent 1 is not a directory

--- a/fs.sql
+++ b/fs.sql
@@ -37,9 +37,25 @@ CREATE TABLE IF NOT EXISTS file_versions (
 CREATE OR REPLACE FUNCTION create_file(user_id INTEGER, filename TEXT, parent_id INTEGER, is_dir BOOLEAN DEFAULT FALSE) RETURNS INTEGER AS $$
 DECLARE
     new_file_id INTEGER;
+    parent_record files%ROWTYPE;
 BEGIN
     IF NOT check_permission(user_id, 'file', 'write') THEN
         RAISE EXCEPTION 'User % does not have permission to create files', user_id;
+    END IF;
+
+    IF parent_id IS NOT NULL THEN
+        SELECT *
+          INTO parent_record
+          FROM files
+         WHERE id = parent_id;
+
+        IF NOT FOUND THEN
+            RAISE EXCEPTION 'Parent directory % does not exist', parent_id;
+        END IF;
+
+        IF NOT parent_record.is_directory THEN
+            RAISE EXCEPTION 'Parent % is not a directory', parent_id;
+        END IF;
     END IF;
 
     INSERT INTO files (name, parent_id, owner_user_id, permissions, is_directory)

--- a/pg_os--1.0.sql
+++ b/pg_os--1.0.sql
@@ -794,9 +794,25 @@ CREATE TABLE IF NOT EXISTS file_versions (
 CREATE OR REPLACE FUNCTION create_file(user_id INTEGER, filename TEXT, parent_id INTEGER, is_dir BOOLEAN DEFAULT FALSE) RETURNS INTEGER AS $$
 DECLARE
     new_file_id INTEGER;
+    parent_record files%ROWTYPE;
 BEGIN
     IF NOT check_permission(user_id, 'file', 'write') THEN
         RAISE EXCEPTION 'User % does not have permission to create files', user_id;
+    END IF;
+
+    IF parent_id IS NOT NULL THEN
+        SELECT *
+          INTO parent_record
+          FROM files
+         WHERE id = parent_id;
+
+        IF NOT FOUND THEN
+            RAISE EXCEPTION 'Parent directory % does not exist', parent_id;
+        END IF;
+
+        IF NOT parent_record.is_directory THEN
+            RAISE EXCEPTION 'Parent % is not a directory', parent_id;
+        END IF;
     END IF;
 
     INSERT INTO files (name, parent_id, owner_user_id, permissions, is_directory)

--- a/sql/create_file.sql
+++ b/sql/create_file.sql
@@ -1,0 +1,22 @@
+-- tests for create_file parent validation
+\set ECHO none
+SET client_min_messages TO warning;
+DROP EXTENSION IF EXISTS pg_os CASCADE;
+CREATE EXTENSION pg_os;
+\set ECHO queries
+\set VERBOSITY terse
+
+-- setup user with file write permission
+INSERT INTO users (username) VALUES ('alice');
+INSERT INTO roles (role_name) VALUES ('file_writer');
+INSERT INTO permissions (role_id, resource_type, action)
+VALUES (1, 'file', 'write');
+INSERT INTO user_roles (user_id, role_id) VALUES (1, 1);
+
+-- create a non-directory parent entry
+INSERT INTO files (id, name, owner_user_id, permissions, is_directory)
+VALUES (1, 'not_a_directory', 1, 'rwxr-----', false);
+
+\set ON_ERROR_STOP off
+SELECT create_file(1, 'child', 1, FALSE);
+\set ON_ERROR_STOP on


### PR DESCRIPTION
## Summary
- ensure create_file loads and validates parent directory entries before creating children
- add a regression test covering attempts to create a file under a non-directory parent
- include the new regression in the default test suite expectations

## Testing
- make installcheck *(fails: required pgxs.mk is unavailable in the test environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d6a7bc38a08328a0c84b6d159687ab