### PR TITLE
Fix unlock predicate and add regression coverage for multi-file locking

### DIFF
--- a/expected/lock_file.out
+++ b/expected/lock_file.out
@@ -1,17 +1,35 @@
 \set ECHO none
 SELECT lock_file(1, 1, 'read');
- lock_file 
+ lock_file
 -----------
- 
+
+(1 row)
+
+SELECT lock_file(1, 2, 'read');
+ lock_file
+-----------
+
 (1 row)
 
 SELECT lock_file(1, 1, 'read');
- lock_file 
+ lock_file
 -----------
- 
+
 (1 row)
 
 SELECT lock_file(1, 999, 'read');
 ERROR:  File not found
 SELECT lock_file(1, 2, 'bad');
 ERROR:  new row for relation "file_locks" violates check constraint "file_locks_lock_mode_check"
+
+SELECT unlock_file(1, 1);
+ unlock_file
+------------
+
+(1 row)
+
+SELECT file_id, locked_by_user, lock_mode FROM file_locks ORDER BY file_id;
+ file_id | locked_by_user | lock_mode 
+---------+----------------+-----------
+       2 |              1 | read
+(1 row)

--- a/pg_os--1.0.sql
+++ b/pg_os--1.0.sql
@@ -941,7 +941,9 @@ $$ LANGUAGE plpgsql;
 -- Unlock a file
 CREATE OR REPLACE FUNCTION unlock_file(user_id INTEGER, file_id INTEGER) RETURNS VOID AS $$
 BEGIN
-    DELETE FROM file_locks WHERE file_id=file_id AND locked_by_user=user_id;
+    DELETE FROM file_locks
+      WHERE file_id = unlock_file.file_id
+        AND locked_by_user = unlock_file.user_id;
 END;
 $$ LANGUAGE plpgsql;
 

--- a/sql/lock_file.sql
+++ b/sql/lock_file.sql
@@ -19,8 +19,15 @@ INSERT INTO user_roles (user_id, role_id) VALUES (1, 1);
 -- successful lock
 SELECT lock_file(1, 1, 'read');
 
+-- ensure multiple locks can coexist
+SELECT lock_file(1, 2, 'read');
+
 \set ON_ERROR_STOP off
 SELECT lock_file(1, 1, 'read');
 SELECT lock_file(1, 999, 'read');
 SELECT lock_file(1, 2, 'bad');
 \set ON_ERROR_STOP on
+
+-- unlock one file and ensure other lock remains
+SELECT unlock_file(1, 1);
+SELECT file_id, locked_by_user, lock_mode FROM file_locks ORDER BY file_id;


### PR DESCRIPTION
## Summary
- ensure unlock_file compares against its function arguments so only the targeted lock is removed
- extend the lock_file regression test to cover unlocking one file while preserving another lock
- update the expected output to reflect the new regression coverage

## Testing
- make installcheck *(fails: missing /usr/lib/postgresql/16/lib/pgxs/src/makefiles/pgxs.mk)*

------
https://chatgpt.com/codex/tasks/task_e_68d6a7b9a44c83289e86823f8084b33d