### PR TITLE
Add regression tests for previously untested subsystems

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,12 @@ REGRESS = pg_os_basic \
           lock_file \
           load_unload_module \
           modules \
+          free_memory \
+          signals \
+          ipc \
+          semaphore_wait \
+          scheduler \
+          power \
           locks_security
 REGRESS_OPTS = --outputdir=$(CURDIR)/tmp_pg_os_regress
 PGXS := $(shell $(PG_CONFIG) --pgxs)

--- a/expected/free_memory.out
+++ b/expected/free_memory.out
@@ -1,0 +1,58 @@
+-- tests for free_memory (single-segment release)
+\set ECHO none
+SELECT create_user('mem_user') AS uid 
+SELECT create_role('mem_role') AS rid 
+SELECT assign_role_to_user(1, 1);
+ assign_role_to_user 
+---------------------
+ 
+(1 row)
+
+SELECT grant_permission_to_role(1, 'memory', 'allocate');
+ grant_permission_to_role 
+--------------------------
+ 
+(1 row)
+
+INSERT INTO processes (name, state, owner_user_id)
+VALUES ('mem_proc', 'running', 1)
+RETURNING id AS pid 
+INSERT INTO memory_segments (size) VALUES (2048);
+SELECT allocate_memory(1, 1, 1024);
+ allocate_memory 
+-----------------
+ 
+(1 row)
+
+SELECT allocated, allocated_to FROM memory_segments ORDER BY id;
+ allocated | allocated_to 
+-----------+--------------
+ t         |            1
+(1 row)
+
+SELECT process_id, segment_id FROM process_memory;
+ process_id | segment_id 
+------------+------------
+          1 |          1
+(1 row)
+
+SELECT free_memory(1, 1, 1);
+ free_memory 
+-------------
+ 
+(1 row)
+
+SELECT allocated, allocated_to FROM memory_segments ORDER BY id;
+ allocated | allocated_to 
+-----------+--------------
+ f         |             
+(1 row)
+
+SELECT count(*) AS process_memory_rows FROM process_memory;
+ process_memory_rows 
+---------------------
+                   0
+(1 row)
+
+SELECT free_memory(1, 1, 1);
+ERROR:  Memory segment 1 is not allocated to process 1

--- a/expected/ipc.out
+++ b/expected/ipc.out
@@ -1,0 +1,79 @@
+-- tests for IPC channels and the user mailbox
+\set ECHO none
+SELECT create_user('producer') AS prod 
+SELECT create_user('consumer') AS cons 
+SELECT create_role('ipc_role') AS rid 
+SELECT assign_role_to_user(1, 1);
+ assign_role_to_user 
+---------------------
+ 
+(1 row)
+
+SELECT assign_role_to_user(2, 1);
+ assign_role_to_user 
+---------------------
+ 
+(1 row)
+
+SELECT grant_permission_to_role(1, 'resource', 'read');
+ grant_permission_to_role 
+--------------------------
+ 
+(1 row)
+
+SELECT grant_permission_to_role(1, 'resource', 'write');
+ grant_permission_to_role 
+--------------------------
+ 
+(1 row)
+
+SELECT grant_permission_to_role(1, 'file', 'read');
+ grant_permission_to_role 
+--------------------------
+ 
+(1 row)
+
+SELECT grant_permission_to_role(1, 'file', 'write');
+ grant_permission_to_role 
+--------------------------
+ 
+(1 row)
+
+SELECT register_channel(1, 'chan1');
+ register_channel 
+------------------
+ 
+(1 row)
+
+SELECT write_channel(1, 'chan1', NULL, 'ping');
+ write_channel 
+---------------
+ 
+(1 row)
+
+SELECT read_channel(2, 'chan1');
+ read_channel 
+--------------
+ ping
+(1 row)
+
+SELECT count(*) AS messages_left FROM channel_messages;
+ messages_left 
+---------------
+             0
+(1 row)
+
+SELECT send_mail(1, 2, 'hello consumer');
+ send_mail 
+-----------
+ 
+(1 row)
+
+SELECT check_mail(2);
+   check_mail   
+----------------
+ hello consumer
+(1 row)
+
+SELECT write_channel(1, 'nope', NULL, 'x');
+ERROR:  Channel not found

--- a/expected/power.out
+++ b/expected/power.out
@@ -1,0 +1,22 @@
+-- tests for set_power_state
+\set ECHO none
+SELECT set_power_state('suspended');
+ set_power_state 
+-----------------
+ 
+(1 row)
+
+SELECT state FROM power_states ORDER BY id DESC LIMIT 1;
+   state   
+-----------
+ suspended
+(1 row)
+
+SELECT set_power_state('banana');
+ERROR:  Invalid power state
+SELECT count(*) AS recorded_states FROM power_states;
+ recorded_states 
+-----------------
+               1
+(1 row)
+

--- a/expected/scheduler.out
+++ b/expected/scheduler.out
@@ -1,0 +1,52 @@
+-- tests for the process and thread schedulers
+\set ECHO none
+SELECT create_user('sched_user') AS uid 
+SELECT create_role('sched_role') AS rid 
+SELECT assign_role_to_user(1, 1);
+ assign_role_to_user 
+---------------------
+ 
+(1 row)
+
+SELECT grant_permission_to_role(1, 'process', 'execute');
+ grant_permission_to_role 
+--------------------------
+ 
+(1 row)
+
+INSERT INTO processes (name, state, priority, owner_user_id)
+VALUES ('sched_proc', 'ready', 5, 1)
+RETURNING id AS pid 
+SELECT schedule_processes(1);
+ schedule_processes 
+--------------------
+ 
+(1 row)
+
+SELECT state FROM processes WHERE id = 1;
+   state    
+------------
+ terminated
+(1 row)
+
+INSERT INTO threads (process_id, name, state)
+VALUES (1, 'sched_thread', 'ready')
+RETURNING id AS tid 
+SELECT schedule_threads();
+ schedule_threads 
+------------------
+ 
+(1 row)
+
+SELECT state FROM threads WHERE id = 1;
+   state    
+------------
+ terminated
+(1 row)
+
+SELECT count(*) AS ready_threads FROM threads WHERE state = 'ready';
+ ready_threads 
+---------------
+             0
+(1 row)
+

--- a/expected/semaphore_wait.out
+++ b/expected/semaphore_wait.out
@@ -1,0 +1,57 @@
+-- tests for semaphore wait/wake behaviour across processes
+\set ECHO none
+SELECT create_user('sem_user') AS uid 
+INSERT INTO processes (name, state, owner_user_id)
+VALUES ('sem_p1', 'running', 1)
+RETURNING id AS p1 
+INSERT INTO processes (name, state, owner_user_id)
+VALUES ('sem_p2', 'running', 1)
+RETURNING id AS p2 
+SELECT create_semaphore('sem', 1, 1);
+ create_semaphore 
+------------------
+ 
+(1 row)
+
+SELECT acquire_semaphore(1, 'sem');
+ acquire_semaphore 
+-------------------
+ 
+(1 row)
+
+SELECT count FROM semaphores WHERE name = 'sem';
+ count 
+-------
+     0
+(1 row)
+
+SELECT acquire_semaphore(2, 'sem');
+ acquire_semaphore 
+-------------------
+ 
+(1 row)
+
+SELECT state, waiting_on_semaphore FROM processes WHERE id = 2;
+  state  | waiting_on_semaphore 
+---------+----------------------
+ waiting | sem
+(1 row)
+
+SELECT release_semaphore(1, 'sem');
+ release_semaphore 
+-------------------
+ 
+(1 row)
+
+SELECT state, waiting_on_semaphore FROM processes WHERE id = 2;
+ state | waiting_on_semaphore 
+-------+----------------------
+ ready | 
+(1 row)
+
+SELECT count FROM semaphores WHERE name = 'sem';
+ count 
+-------
+     1
+(1 row)
+

--- a/expected/signals.out
+++ b/expected/signals.out
@@ -1,0 +1,79 @@
+-- tests for send_signal / handle_signals
+\set ECHO none
+SELECT create_user('signaler') AS uid 
+SELECT create_role('sig_role') AS rid 
+SELECT assign_role_to_user(1, 1);
+ assign_role_to_user 
+---------------------
+ 
+(1 row)
+
+SELECT grant_permission_to_role(1, 'process', 'execute');
+ grant_permission_to_role 
+--------------------------
+ 
+(1 row)
+
+INSERT INTO processes (name, state, owner_user_id)
+VALUES ('sig_proc', 'running', 1)
+RETURNING id AS pid 
+SELECT send_signal(1, 'SIGSTOP');
+ send_signal 
+-------------
+ 
+(1 row)
+
+SELECT handle_signals(1, 1);
+ handle_signals 
+----------------
+ 
+(1 row)
+
+SELECT state FROM processes WHERE id = 1;
+  state  
+---------
+ waiting
+(1 row)
+
+SELECT send_signal(1, 'SIGCONT');
+ send_signal 
+-------------
+ 
+(1 row)
+
+SELECT handle_signals(1, 1);
+ handle_signals 
+----------------
+ 
+(1 row)
+
+SELECT state FROM processes WHERE id = 1;
+ state 
+-------
+ ready
+(1 row)
+
+SELECT send_signal(1, 'SIGTERM');
+ send_signal 
+-------------
+ 
+(1 row)
+
+SELECT handle_signals(1, 1);
+ handle_signals 
+----------------
+ 
+(1 row)
+
+SELECT state FROM processes WHERE id = 1;
+   state    
+------------
+ terminated
+(1 row)
+
+SELECT count(*) AS remaining_signals FROM signals WHERE process_id = 1;
+ remaining_signals 
+-------------------
+                 0
+(1 row)
+

--- a/sql/free_memory.sql
+++ b/sql/free_memory.sql
@@ -1,0 +1,32 @@
+-- tests for free_memory (single-segment release)
+\set ECHO none
+SET client_min_messages TO warning;
+DROP EXTENSION IF EXISTS pg_os CASCADE;
+CREATE EXTENSION pg_os;
+\set ECHO queries
+\set VERBOSITY terse
+
+-- setup: user with memory permission, a process, and one free segment
+SELECT create_user('mem_user') AS uid \gset
+SELECT create_role('mem_role') AS rid \gset
+SELECT assign_role_to_user(:uid, :rid);
+SELECT grant_permission_to_role(:rid, 'memory', 'allocate');
+INSERT INTO processes (name, state, owner_user_id)
+VALUES ('mem_proc', 'running', :uid)
+RETURNING id AS pid \gset
+INSERT INTO memory_segments (size) VALUES (2048);
+
+-- allocate, then confirm the segment is owned by the process
+SELECT allocate_memory(:uid, :pid, 1024);
+SELECT allocated, allocated_to FROM memory_segments ORDER BY id;
+SELECT process_id, segment_id FROM process_memory;
+
+-- free it and confirm the segment is released
+SELECT free_memory(:uid, :pid, 1);
+SELECT allocated, allocated_to FROM memory_segments ORDER BY id;
+SELECT count(*) AS process_memory_rows FROM process_memory;
+
+-- freeing a segment that is not allocated to the process fails
+\set ON_ERROR_STOP off
+SELECT free_memory(:uid, :pid, 1);
+\set ON_ERROR_STOP on

--- a/sql/ipc.sql
+++ b/sql/ipc.sql
@@ -1,0 +1,34 @@
+-- tests for IPC channels and the user mailbox
+\set ECHO none
+SET client_min_messages TO warning;
+DROP EXTENSION IF EXISTS pg_os CASCADE;
+CREATE EXTENSION pg_os;
+\set ECHO queries
+\set VERBOSITY terse
+
+-- setup: two users sharing a role with the relevant permissions
+SELECT create_user('producer') AS prod \gset
+SELECT create_user('consumer') AS cons \gset
+SELECT create_role('ipc_role') AS rid \gset
+SELECT assign_role_to_user(:prod, :rid);
+SELECT assign_role_to_user(:cons, :rid);
+SELECT grant_permission_to_role(:rid, 'resource', 'read');
+SELECT grant_permission_to_role(:rid, 'resource', 'write');
+SELECT grant_permission_to_role(:rid, 'file', 'read');
+SELECT grant_permission_to_role(:rid, 'file', 'write');
+
+-- channels: register, write, then drain
+SELECT register_channel(:prod, 'chan1');
+SELECT write_channel(:prod, 'chan1', NULL, 'ping');
+SELECT read_channel(:cons, 'chan1');
+-- reading a channel removes the delivered messages
+SELECT count(*) AS messages_left FROM channel_messages;
+
+-- mailbox: send then check
+SELECT send_mail(:prod, :cons, 'hello consumer');
+SELECT check_mail(:cons);
+
+-- writing to a missing channel fails
+\set ON_ERROR_STOP off
+SELECT write_channel(:prod, 'nope', NULL, 'x');
+\set ON_ERROR_STOP on

--- a/sql/power.sql
+++ b/sql/power.sql
@@ -1,0 +1,19 @@
+-- tests for set_power_state
+\set ECHO none
+SET client_min_messages TO warning;
+DROP EXTENSION IF EXISTS pg_os CASCADE;
+CREATE EXTENSION pg_os;
+\set ECHO queries
+\set VERBOSITY terse
+
+-- a valid transition is recorded
+SELECT set_power_state('suspended');
+SELECT state FROM power_states ORDER BY id DESC LIMIT 1;
+
+-- an unknown state is rejected
+\set ON_ERROR_STOP off
+SELECT set_power_state('banana');
+\set ON_ERROR_STOP on
+
+-- the rejected state was not recorded
+SELECT count(*) AS recorded_states FROM power_states;

--- a/sql/scheduler.sql
+++ b/sql/scheduler.sql
@@ -1,0 +1,28 @@
+-- tests for the process and thread schedulers
+\set ECHO none
+SET client_min_messages TO warning;
+DROP EXTENSION IF EXISTS pg_os CASCADE;
+CREATE EXTENSION pg_os;
+\set ECHO queries
+\set VERBOSITY terse
+
+-- setup: a user allowed to execute processes
+SELECT create_user('sched_user') AS uid \gset
+SELECT create_role('sched_role') AS rid \gset
+SELECT assign_role_to_user(:uid, :rid);
+SELECT grant_permission_to_role(:rid, 'process', 'execute');
+
+-- a ready process is driven to completion by the scheduler
+INSERT INTO processes (name, state, priority, owner_user_id)
+VALUES ('sched_proc', 'ready', 5, :uid)
+RETURNING id AS pid \gset
+SELECT schedule_processes(:uid);
+SELECT state FROM processes WHERE id = :pid;
+
+-- the thread scheduler drains ready threads (and terminates, no infinite loop)
+INSERT INTO threads (process_id, name, state)
+VALUES (:pid, 'sched_thread', 'ready')
+RETURNING id AS tid \gset
+SELECT schedule_threads();
+SELECT state FROM threads WHERE id = :tid;
+SELECT count(*) AS ready_threads FROM threads WHERE state = 'ready';

--- a/sql/semaphore_wait.sql
+++ b/sql/semaphore_wait.sql
@@ -1,0 +1,30 @@
+-- tests for semaphore wait/wake behaviour across processes
+\set ECHO none
+SET client_min_messages TO warning;
+DROP EXTENSION IF EXISTS pg_os CASCADE;
+CREATE EXTENSION pg_os;
+\set ECHO queries
+\set VERBOSITY terse
+
+-- setup: two processes contending for a binary semaphore
+SELECT create_user('sem_user') AS uid \gset
+INSERT INTO processes (name, state, owner_user_id)
+VALUES ('sem_p1', 'running', :uid)
+RETURNING id AS p1 \gset
+INSERT INTO processes (name, state, owner_user_id)
+VALUES ('sem_p2', 'running', :uid)
+RETURNING id AS p2 \gset
+SELECT create_semaphore('sem', 1, 1);
+
+-- first process acquires the only permit, dropping the count to zero
+SELECT acquire_semaphore(:p1, 'sem');
+SELECT count FROM semaphores WHERE name = 'sem';
+
+-- second process finds none available and is parked as waiting
+SELECT acquire_semaphore(:p2, 'sem');
+SELECT state, waiting_on_semaphore FROM processes WHERE id = :p2;
+
+-- releasing the permit wakes the oldest waiter
+SELECT release_semaphore(:p1, 'sem');
+SELECT state, waiting_on_semaphore FROM processes WHERE id = :p2;
+SELECT count FROM semaphores WHERE name = 'sem';

--- a/sql/signals.sql
+++ b/sql/signals.sql
@@ -1,0 +1,34 @@
+-- tests for send_signal / handle_signals
+\set ECHO none
+SET client_min_messages TO warning;
+DROP EXTENSION IF EXISTS pg_os CASCADE;
+CREATE EXTENSION pg_os;
+\set ECHO queries
+\set VERBOSITY terse
+
+-- setup: a user that may execute processes, plus a running process
+SELECT create_user('signaler') AS uid \gset
+SELECT create_role('sig_role') AS rid \gset
+SELECT assign_role_to_user(:uid, :rid);
+SELECT grant_permission_to_role(:rid, 'process', 'execute');
+INSERT INTO processes (name, state, owner_user_id)
+VALUES ('sig_proc', 'running', :uid)
+RETURNING id AS pid \gset
+
+-- SIGSTOP pauses a running process
+SELECT send_signal(:pid, 'SIGSTOP');
+SELECT handle_signals(:uid, :pid);
+SELECT state FROM processes WHERE id = :pid;
+
+-- SIGCONT moves a waiting process back to ready
+SELECT send_signal(:pid, 'SIGCONT');
+SELECT handle_signals(:uid, :pid);
+SELECT state FROM processes WHERE id = :pid;
+
+-- SIGTERM terminates the process
+SELECT send_signal(:pid, 'SIGTERM');
+SELECT handle_signals(:uid, :pid);
+SELECT state FROM processes WHERE id = :pid;
+
+-- handled signals are consumed
+SELECT count(*) AS remaining_signals FROM signals WHERE process_id = :pid;


### PR DESCRIPTION
## Summary
Expands the regression suite from **13 → 19 tests**, covering subsystems that previously had no tests at all (and where several of the bugs fixed in #67 had been hiding):

- **free_memory** – single-segment allocate/free plus the double-free error path
- **signals** – `SIGSTOP` → waiting, `SIGCONT` → ready, `SIGTERM` → terminated, and signal consumption
- **ipc** – channel write/read draining and the user mailbox, plus the missing-channel error
- **semaphore_wait** – cross-process semaphore wait/wake (one process parks as waiting, a release wakes it)
- **scheduler** – `schedule_processes` drives a ready process to `terminated`; `schedule_threads` drains ready threads *without looping forever* (regression guard for the infinite-loop fix in #67)
- **power** – `set_power_state` records valid states and rejects unknown ones

All tests are deterministic and pass via `make installcheck` (19/19).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ty3Rkif9Vfe95w8TMiKB4b)_