### PR TITLE
Enforce the semaphore count <= max_count invariant

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,8 @@ REGRESS = pg_os_basic \
           lock_file \
           load_unload_module \
           modules \
-          locks_security
+          locks_security \
+          semaphore_validation
 REGRESS_OPTS = --outputdir=$(CURDIR)/tmp_pg_os_regress
 PGXS := $(shell $(PG_CONFIG) --pgxs)
 include $(PGXS)

--- a/expected/semaphore_validation.out
+++ b/expected/semaphore_validation.out
@@ -1,0 +1,27 @@
+-- create_semaphore must reject parameters that would violate the
+-- "0 <= count <= max_count, max_count >= 1" invariant.
+\set ECHO none
+SELECT create_semaphore('ok', 1, 2);
+ create_semaphore 
+------------------
+ 
+(1 row)
+
+SELECT name, count, max_count FROM semaphores WHERE name = 'ok';
+ name | count | max_count 
+------+-------+-----------
+ ok   |     1 |         2
+(1 row)
+
+SELECT create_semaphore('too_many', 5, 1);
+ERROR:  Semaphore initial count 5 must be between 0 and the maximum 1
+SELECT create_semaphore('negative', -1, 2);
+ERROR:  Semaphore initial count -1 must be between 0 and the maximum 2
+SELECT create_semaphore('no_max', 0, 0);
+ERROR:  Semaphore maximum must be at least 1 (got 0)
+SELECT count(*) AS semaphore_count FROM semaphores;
+ semaphore_count 
+-----------------
+               1
+(1 row)
+

--- a/pg_os--1.0.sql
+++ b/pg_os--1.0.sql
@@ -462,7 +462,9 @@ CREATE TABLE IF NOT EXISTS semaphores (
     id SERIAL PRIMARY KEY,
     name TEXT UNIQUE NOT NULL,
     count INTEGER NOT NULL CHECK (count >= 0),
-    max_count INTEGER NOT NULL CHECK (max_count >= 1)
+    max_count INTEGER NOT NULL CHECK (max_count >= 1),
+    -- a semaphore can never hold more permits than its maximum
+    CHECK (count <= max_count)
 );
 
 
@@ -533,6 +535,13 @@ GRANT EXECUTE ON FUNCTION unlock_mutex(INTEGER, TEXT) TO PUBLIC;
 -- create a semaphore
 CREATE OR REPLACE FUNCTION create_semaphore(sem_name TEXT, initial_count INTEGER, max_val INTEGER) RETURNS VOID AS $$
 BEGIN
+    IF max_val < 1 THEN
+        RAISE EXCEPTION 'Semaphore maximum must be at least 1 (got %)', max_val;
+    END IF;
+    IF initial_count < 0 OR initial_count > max_val THEN
+        RAISE EXCEPTION 'Semaphore initial count % must be between 0 and the maximum %', initial_count, max_val;
+    END IF;
+
     INSERT INTO semaphores (name, count, max_count)
     VALUES (sem_name, initial_count, max_val);
 END;

--- a/sql/semaphore_validation.sql
+++ b/sql/semaphore_validation.sql
@@ -1,0 +1,24 @@
+-- create_semaphore must reject parameters that would violate the
+-- "0 <= count <= max_count, max_count >= 1" invariant.
+\set ECHO none
+SET client_min_messages TO warning;
+DROP EXTENSION IF EXISTS pg_os CASCADE;
+CREATE EXTENSION pg_os;
+\set ECHO queries
+\set VERBOSITY terse
+
+-- a valid semaphore is accepted
+SELECT create_semaphore('ok', 1, 2);
+SELECT name, count, max_count FROM semaphores WHERE name = 'ok';
+
+\set ON_ERROR_STOP off
+-- initial count greater than the maximum is rejected
+SELECT create_semaphore('too_many', 5, 1);
+-- negative initial count is rejected
+SELECT create_semaphore('negative', -1, 2);
+-- a maximum below 1 is rejected
+SELECT create_semaphore('no_max', 0, 0);
+\set ON_ERROR_STOP on
+
+-- none of the invalid semaphores were created
+SELECT count(*) AS semaphore_count FROM semaphores;


### PR DESCRIPTION
## Bug
`create_semaphore` accepted parameters that produced an impossible semaphore:

```sql
SELECT create_semaphore('broken', 5, 1);
SELECT name, count, max_count FROM semaphores WHERE name = 'broken';
--   name  | count | max_count
-- --------+-------+-----------
--  broken |     5 |         1   <- 5 held permits, max of 1
```

The table only checked `count >= 0` and `max_count >= 1`, never their relationship, so a semaphore could be created already over its own ceiling.

## Fix
- Add `CHECK (count <= max_count)` on the `semaphores` table (enforces the invariant even against direct inserts and the existing acquire/release paths, which already keep `count` within `[0, max_count]`).
- Validate the arguments in `create_semaphore` so callers get a clear message instead of a silently broken (or cryptic constraint-named) error.

## Test
Adds `semaphore_validation`, covering the accepted case plus the three rejected ones (count > max, negative count, max < 1) and confirming the invalid semaphores are not created. Suite green (14/14 on this branch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ty3Rkif9Vfe95w8TMiKB4b)_