### PR TITLE
Fix broken Makefile REGRESS list and CI package conflict

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,6 +4,9 @@ on:
   push:
   pull_request:
 
+env:
+  PG_MAJOR: "16"
+
 jobs:
   test:
     runs-on: ubuntu-latest
@@ -13,30 +16,42 @@ jobs:
       - name: Install PostgreSQL and development headers
         run: |
           sudo apt-get update
-          # Server, contrib modules, client library and the PGXS build headers
-          sudo apt-get install -y postgresql postgresql-contrib libpq-dev postgresql-server-dev-all
+          # The GitHub runner image already has the PGDG apt repo and a newer
+          # postgresql-common, which conflicts with the archive's
+          # postgresql-server-dev-all meta-package. Install versioned packages
+          # so apt stays on the PGDG line.
+          sudo apt-get install -y \
+            "postgresql-${PG_MAJOR}" \
+            "postgresql-server-dev-${PG_MAJOR}" \
+            libpq-dev
 
-      - name: Start PostgreSQL
+      - name: Start the PostgreSQL cluster
         run: |
-          # Determine the installed major version and start the default cluster
-          PG_MAJOR=$(pg_config --version | awk '{print $2}' | cut -d. -f1)
-          echo "PG_MAJOR=$PG_MAJOR" >> "$GITHUB_ENV"
-          sudo pg_ctlcluster "$PG_MAJOR" main start
+          # The cluster may already exist on the runner; create it only if not.
+          if ! pg_lsclusters -h | awk '{print $1, $2}' | grep -qx "${PG_MAJOR} main"; then
+            sudo pg_createcluster "${PG_MAJOR}" main
+          fi
+          sudo pg_ctlcluster "${PG_MAJOR}" main start || true
+          # Whatever port the cluster ended up on, route all later steps to it.
+          PORT=$(pg_lsclusters -h | awk -v v="${PG_MAJOR}" '$1==v && $2=="main" {print $3}')
+          echo "PGHOST=/var/run/postgresql" >> "$GITHUB_ENV"
+          echo "PGPORT=$PORT" >> "$GITHUB_ENV"
 
       - name: Create a superuser role for the runner
         run: |
           # pg_regress connects over the local socket as the current OS user via
           # peer authentication, so that user needs a matching superuser role.
-          sudo -u postgres createuser --superuser "$(whoami)"
-          sudo -u postgres createdb "$(whoami)"
+          sudo -u postgres psql -p "$PGPORT" -d postgres \
+            -c "CREATE ROLE \"$(whoami)\" SUPERUSER LOGIN;" || true
+          sudo -u postgres createdb -p "$PGPORT" -O "$(whoami)" "$(whoami)" || true
 
       - name: Build and install the extension
         run: |
-          make
-          sudo make install
+          make PG_CONFIG="/usr/lib/postgresql/${PG_MAJOR}/bin/pg_config"
+          sudo make PG_CONFIG="/usr/lib/postgresql/${PG_MAJOR}/bin/pg_config" install
 
       - name: Run regression tests
-        run: make installcheck
+        run: make PG_CONFIG="/usr/lib/postgresql/${PG_MAJOR}/bin/pg_config" installcheck
 
       - name: Show regression diffs on failure
         if: failure()

--- a/Makefile
+++ b/Makefile
@@ -5,16 +5,22 @@ REGRESS = pg_os_basic \
           create_user \
           check_permission \
           create_process \
+          scheduler \
+          signals \
           allocate_memory \
           allocate_page \
+          free_memory \
           free_all_memory_for_process \
           create_file \
           file_versioning \
           lock_file \
+          ipc \
           load_unload_module \
           modules \
+          semaphore_wait \
+          semaphore_validation \
+          power \
           locks_security \
-          semaphore_validation
           schema_install
 REGRESS_OPTS = --outputdir=$(CURDIR)/tmp_pg_os_regress
 PGXS := $(shell $(PG_CONFIG) --pgxs)


### PR DESCRIPTION
Two problems are currently leaving `main` **unbuildable and CI red**.

## 1. Mangled `REGRESS` list (merge fallout)
Merging #68, #69 and #70 mis-resolved the `REGRESS` list in the `Makefile`:
- A missing line-continuation `\` after `semaphore_validation` left `schema_install` dangling, so **`make` itself fails** with `Makefile:18: *** missing separator`.
- The six subsystem tests added in #68 (`free_memory`, `signals`, `ipc`, `semaphore_wait`, `scheduler`, `power`) were **dropped from the list**, even though their `sql/` and `expected/` files are committed — so they silently stopped running.

Rebuilt the list with every test (21 total) and correct continuations. `make installcheck` → **All 21 tests passed** locally.

## 2. CI install step aborts on a package conflict
The workflow installed `postgresql-server-dev-all`, whose dependency on the archive's `postgresql-common` conflicts with the newer **PGDG `postgresql-common`** already present on the runner image:

```
postgresql-server-dev-all : Depends: postgresql-common (= 257build1.1) but 291.pgdg24.04+1 is to be installed
E: Unable to correct problems, you have held broken packages.
```

So the job died in ~10s, before any test ran. Now it installs **versioned PGDG packages** (`postgresql-16` + `postgresql-server-dev-16`), detects the cluster's actual port, and pins `PG_CONFIG` so build/install/test all target the same server.

## Validation
- `make` parses and `make installcheck` passes all 21 tests locally.
- Port detection, cluster-exists check, and the exact `make PG_CONFIG=… installcheck` invocation were validated locally. The apt resolution and runner-role steps can only be confirmed on the GitHub runner — this PR's own CI run is the check for that.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ty3Rkif9Vfe95w8TMiKB4b)_